### PR TITLE
TASK: Improve nbsp style

### DIFF
--- a/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
+++ b/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
@@ -18,7 +18,7 @@
     position: relative;
     border-radius: 3px;
     margin: 0 0.05ch;
-    position: relative;
+    padding: 0 0.1ch;
 }
 
 .ck-content .nbsp::before {

--- a/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
+++ b/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
@@ -32,11 +32,11 @@
 
 .ck-content .nbsp::after {
     content: '';
-    width: 100%;
-    height: 0.6ch;
     position: absolute;
-    bottom: 0.3ch;
+    left: 0;
     right: 0;
+    bottom: 0.3ch;
+    height: 0.6ch;
     border-left: 0.2ch solid currentColor;
     border-right: 0.2ch solid currentColor;
 }

--- a/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
+++ b/Resources/Private/Scripts/HyphensEditor/src/plugins/hyphens.vanilla-css
@@ -15,29 +15,28 @@
 }
 
 .ck-content .nbsp {
-    padding: 0 0.4em;
     position: relative;
     border-radius: 3px;
-    margin: 0 0.3em;
+    margin: 0 0.05ch;
     position: relative;
 }
 
 .ck-content .nbsp::before {
     content: '';
-    border-bottom: 2px solid currentColor;
+    border-bottom: 0.2ch solid currentColor;
     width: 100%;
     position: absolute;
     right: 0;
-    bottom: 3px;
+    bottom: 0.3ch;
 }
 
 .ck-content .nbsp::after {
     content: '';
     width: 100%;
-    height: 5px;
+    height: 0.6ch;
     position: absolute;
-    bottom: 4px;
+    bottom: 0.3ch;
     right: 0;
-    border-left: 2px solid currentColor;
-    border-right: 2px solid currentColor;
+    border-left: 0.2ch solid currentColor;
+    border-right: 0.2ch solid currentColor;
 }


### PR DESCRIPTION
A whitespace is around 0.6 ch wide, and it makes sense that the character is around the same width as it would be normally rendered.

Also, with fixed pixels, the char looks tiny in h1 and hugh in p. This adapts the size to the used font-family and font-size.