### PR TITLE
Add Neos 9 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     }
   ],
   "require": {
-    "neos/neos": "^7.3 || ^8.0",
-    "neos/neos-ui": "^7.3 || ^8.0"
+    "neos/neos": "^7.3 || ^8.0 || ^9.0",
+    "neos/neos-ui": "^7.3 || ^8.0 || ^9.0"
   },
   "extra": {
     "neos": {


### PR DESCRIPTION
I adjusted the requirements to allow the package for Neos 9 projects. Tested it with a Neos.Demo project on Neos 9 and it works without any problems.